### PR TITLE
Support foreign keys

### DIFF
--- a/packages/meteor-postgres/lib/server.coffee
+++ b/packages/meteor-postgres/lib/server.coffee
@@ -37,7 +37,14 @@ _.extend SQL.Server::, SQL.Sql::
 # @param tableObj
 ###
 
-SQL.Server::createTable = (tableObj) ->
+SQL.Server::createTable = (tableObj, constraints = []) ->
+  check constraints, [Match.Where((v) ->
+    # tuple(String, Object)
+    check v, Array
+    check v[0], String
+    check v[1], Object
+    v.length == 2)]
+
   startString = "CREATE TABLE IF NOT EXISTS \"#{@table}\" ("
   item = undefined
   subKey = undefined
@@ -59,6 +66,14 @@ SQL.Server::createTable = (tableObj) ->
     inputString += ', '
 
   startString += 'id varchar(255) primary key,' if inputString.indexOf(' id') is -1
+
+  # TableConstraints above are actually column constraints
+  # as specified by SQL standard.
+  # The following constraints are real table constraints.
+  # TODO - rename accordingly
+  for constraint in constraints
+    fn = @_Constraints[constraint[0]]
+    inputString += fn(constraint[1]) + ', ' if fn
 
   watchTrigger = 'watched_table_trigger'
   @inputString = """

--- a/packages/meteor-postgres/lib/sql.coffee
+++ b/packages/meteor-postgres/lib/sql.coffee
@@ -32,6 +32,30 @@ SQL.Sql::_TableConstraints =
   $primary: 'primary key'
 
 ###*
+# Table Constraints (the ones above are column constraints)
+# @type {{$foreign: function}}
+# @private
+###
+
+SQL.Sql::_Constraints =
+  $foreign: (opts) ->
+    check opts,
+      $key: [String]
+      $ref:
+        $table: String
+        $cols: Match.Optional([String])
+
+    quote = (v) -> "\"#{v.replace('"', '\\"')}\""
+    sql = "FOREIGN KEY ("
+    sql += _.map(opts.$key, quote).join(', ')
+    sql += ") REFERENCES #{quote opts.$ref.$table}"
+    if opts.$ref.$cols
+      sql += " ("
+      sql += _.map(opts.$ref.$cols, quote).join(', ')
+      sql += ")"
+    sql
+
+###*
 # Notes: Deletes cascade
 # SQL: DROP TABLE <table>
 ###

--- a/packages/meteor-postgres/package.js
+++ b/packages/meteor-postgres/package.js
@@ -14,6 +14,7 @@ Package.onUse(function (api) {
   api.versionsFrom('1.1.0.2');
   api.use('coffeescript');
   api.use('underscore');
+  api.use('check');
   api.use('tracker');
   api.use('ddp');
   api.use('agershun:alasql@0.2.0');


### PR DESCRIPTION
This add supports for foreign key table constraints on the server side.
A new parameter was added to `SQL.Server::createTable` which specifies the table constraints to be used in the following format:

```
[ [ <constraint type> <constraint options>]
  ... ]
```

Currently the only constraint supported is FOREIGN KEY with the following inputs:

```
constraint type = '$foreign'
constraint options = { $key: [<column1>, ...],
                       $ref: { $table: <table name>,
                               $cols: [<foreign column 1>, ...] }}
```

But new ones can be added easily by extending the `SQL.Sql::_Constraints` object with new functions from options to a SQL clause.
